### PR TITLE
doc: Fix unmatched parenthesis in intro.qbk

### DIFF
--- a/doc/intro.qbk
+++ b/doc/intro.qbk
@@ -15,7 +15,7 @@ always before the parent. Coroutines (the term was introduced by Melvin
 Conway [footnote Conway, Melvin E.. "Design of a Separable Transition-Diagram Compiler".
 Commun. ACM, Volume 6 Issue 7, July 1963, Article No. 7]),
 are a generalization of routines (Donald Knuth [footnote Knuth, Donald Ervin (1997).
-"Fundamental Algorithms. The Art of Computer Programming 1", (3rd ed.)].
+"Fundamental Algorithms. The Art of Computer Programming 1", (3rd ed.)]).
 The principal difference between coroutines and routines
 is that a coroutine enables explicit suspend and resume of its progress via
 additional operations by preserving execution state and thus provides an


### PR DESCRIPTION
Just a small commit that fixes a unmatched '(' parenthesis in the introduction.

xkcd 859 reference omited.

)